### PR TITLE
Update .gitignore and package.json for dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+node_modules/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,13 +5,16 @@
   "dependencies": {
     "cra-template": "1.2.0",
     "leaflet": "^1.9.4",
+    "nth-check": "^2.1.1",
+    "postcss": "^8.5.3",
     "react": "^19.0.0",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^19.0.0",
     "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.2.0",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
+    "serialize-javascript": "^6.0.2",
     "web-vitals": "^4.2.4"
   },
   "scripts": {
@@ -37,5 +40,11 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "resolutions": {
+    "postcss": "^8.4.31",
+    "nth-check": "^2.0.1",
+    "serialize-javascript": "^6.0.2"
   }
+
 }


### PR DESCRIPTION
Add `node_modules` to .gitignore and update `package.json` to address deprecation issues with `react-scripts` and manage other dependencies.